### PR TITLE
Add Cursor Cloud specific development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,3 +378,10 @@ If a change makes the system feel smarter but harder to reason about, it is usua
 - Copy `.env.example` to `.env` and fill required values. The `.env` file is gitignored.
 - Google OAuth credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`) are needed for login. Without real credentials, the OAuth redirect still works but Google will reject the auth attempt.
 - `NEXTAUTH_SECRET` and `CRON_SECRET` can be any non-empty strings for local dev.
+- The test Google account has 2FA enabled. Automated credential-based login will fail at Google's verification step. Use the Desktop pane for interactive login, or ask the user to log in and preserve the session.
+
+### First login and onboarding
+
+- On first authenticated visit, the app redirects to `/onboarding-test-flow` with a multi-step wizard: welcome, phone pairing (skippable), inbox analysis (fetches labels, scans emails, analyzes senders, groups by projects), label selection, and then the main dashboard.
+- The inbox analysis step calls the Gmail API and the Gemini API; it requires valid `GOOGLE_GENERATIVE_AI_API_KEY` and a connected Gmail account.
+- After onboarding completes, the main view is the Queue page at `/` showing "Your queue is empty. Rest well." until emails are processed by the worker pipeline.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with operational notes discovered during development environment setup. These instructions help future cloud agents bootstrap and run the Clira development environment correctly.

## What changed

- Added documentation for Docker infrastructure setup (PostgreSQL 16 + pgvector on port 15432, Redis 7 on port 16379)
- Documented the fresh-volume gotcha for the DB init script and pgvector extension requirement
- Documented app/worker startup commands and the `/api/health` auth behavior
- Noted the pre-existing test failure in `executive-agent-selector.test.ts`
- Documented minimal `.env` configuration requirements for local development
- Documented Google 2FA blocker for automated login and Desktop pane workaround
- Documented onboarding flow steps and Gmail/Gemini API dependencies

## Verification

- `npm run lint` passes cleanly (0 warnings/errors)
- `npm test` passes 193/194 tests (1 pre-existing failure in `executive-agent-selector.test.ts`)
- `npm run build:worker` compiles successfully
- `npm run dev` starts the Next.js dev server on port 3000
- Full Google OAuth login completed successfully (via Desktop pane for 2FA)
- Onboarding flow completed: inbox analysis, label generation, dashboard loaded
- Settings pages (Account, Assistant & Replies) verified working with connected Gmail account
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0756345-5e6b-4bea-9e00-37abcaa00f24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0756345-5e6b-4bea-9e00-37abcaa00f24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

